### PR TITLE
Use $scenario_data for TFTP path

### DIFF
--- a/manifests/kickstart.pp
+++ b/manifests/kickstart.pp
@@ -505,7 +505,7 @@ define pxe_install::kickstart (
       ensure        => $ensure,
       ostype        => $ostype,
       prefix        => $prefix,
-      path          => $path,
+      path          => $scenario_data,
       ksurl         => $ksurl,
       ksdevice      => $network_data['ksdevice'],
       puppetenv     => $env,


### PR DESCRIPTION
Needed to ensure the `path` parameter in the pxelinux.cfg/<node> file contains the correct value for the boot scenario (`bios`/`efi64`)