### PR TITLE
initrdfile needs to be on same line

### DIFF
--- a/templates/windows/tftp-entry.epp
+++ b/templates/windows/tftp-entry.epp
@@ -8,5 +8,4 @@ label ks
         menu label ^ks
         menu default
         com32 linux.c32
-        APPEND <%= $mirror_host %><%= $mirror_uri %>/wimboot
-        initrdfile=<%= $mirror_host %><%= $mirror_uri %>/boot/bootmgr,<%= $mirror_host %><%= $mirror_uri %>/boot/bcd,<%= $mirror_host %><%= $mirror_uri %>/boot/boot.sdi,<%= $mirror_host %><%= $mirror_uri %>/sources/boot.wim
+        APPEND <%= $mirror_host %><%= $mirror_uri %>/wimboot initrdfile=<%= $mirror_host %><%= $mirror_uri %>/boot/bootmgr,<%= $mirror_host %><%= $mirror_uri %>/boot/bcd,<%= $mirror_host %><%= $mirror_uri %>/boot/boot.sdi,<%= $mirror_host %><%= $mirror_uri %>/sources/boot.wim


### PR DESCRIPTION
Fixes `FATAL: no bootmgr.exe` error message during legacy BIOS PXE boot